### PR TITLE
fix: missing module status code

### DIFF
--- a/.build/environment/test/config.yml
+++ b/.build/environment/test/config.yml
@@ -1,7 +1,7 @@
 ---
 manifest:
   resolvers:
-  - name: inline    
+  - name: inline
     type: literal
 
 data:
@@ -99,7 +99,7 @@ data:
   resolvers:
   - resolver: inline
     prop:
-      value: "feature/PHP7.4"
+      value: "master"
 # -----------
 # third party
 # -----------

--- a/cmfiveTests.php
+++ b/cmfiveTests.php
@@ -5,7 +5,7 @@ use Symfony\Component\Yaml\Yaml;
 
 if (!(isset($argc) && isset($argv))) {
     echo "No action is possible.";
-    exit();
+    exit(1);
 }
 
 defined('DS') || define('DS', DIRECTORY_SEPARATOR);
@@ -138,27 +138,38 @@ function offerMenuTests()
 
 function moduleRunner($runModule, $silent = false)
 {
-
     unitRunner($runModule);
     purgeTestCode();
     registerConfig();
     $found = chaseModules("all");
     registerHelpers($found);
-    //$silent = false;
+
+    $module_found = false;
 
     foreach ($found as $capabilities => $capability) {
-        if ($capabilities == "Tests") {
-            foreach ($capability as $module => $resources) {
-                if ($module == $runModule) {
-                    foreach ($resources as $resource) {
-                        $codeCeptCommand = DEBUG_RUN . "  " . $resource;
-                        $packBar = "\nO" . str_repeat("-", strlen($codeCeptCommand) + 2) . "O\n";
-                        echo $packBar . "| " . $codeCeptCommand . " |" . $packBar;
-                        $silent = launchCodecept($codeCeptCommand, $silent);
-                    }
-                }
+        if ($capabilities !== "Tests") {
+            continue;
+        }
+
+        foreach ($capability as $module => $resources) {
+            if ($module !== $runModule) {
+                continue;
+            }
+
+            $module_found = true;
+
+            foreach ($resources as $resource) {
+                $codeCeptCommand = DEBUG_RUN . "  " . $resource;
+                $packBar = "\nO" . str_repeat("-", strlen($codeCeptCommand) + 2) . "O\n";
+                echo $packBar . "| " . $codeCeptCommand . " |" . $packBar;
+                $silent = launchCodecept($codeCeptCommand, $silent);
             }
         }
+    }
+
+    if (!$module_found) {
+        echo "Error: Unable to find $runModule module\n";
+        exit(1);
     }
 }
 


### PR DESCRIPTION
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [x] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

## Description
A non-zero exit status code wasn't been used when trying to run tests on a module that didn't exist. This was causing tests to appear as they had passed when none had actually run.

## Changelog
- Added exit status code when a module cannot be found.
- Added exit status code when $argc and $argv cannot be found.
- Updated test cmfive_core_ref to be master.