### PR TITLE
fix: No Arrays To Codecept MouseOver WIP

### DIFF
--- a/test/Codeception/tests/boilerplate/acceptance/helpers/CmfiveSite.php
+++ b/test/Codeception/tests/boilerplate/acceptance/helpers/CmfiveSite.php
@@ -160,7 +160,9 @@ class CmfiveSite extends \Codeception\Module
         //$category, "section.top-bar-section ul.left"
         $I->waitForElement("//section[@class='top-bar-section']/ul[@class='left']/li/a[contains(text(),'{$category}')]", 2);
         $I->click("//section[@class='top-bar-section']/ul[@class='left']/li/a[contains(text(),'{$category}')]");
-        $I->moveMouseOver(['css' => '#topnav_' . strtolower($category)]);
+        // Codeception type hints don't like old style : 'css' => '#topnav_' . strtolower($category)]
+        // see: https://github.com/Codeception/module-webdriver/issues/70
+        $I->moveMouseOver("//section[@class='top-bar-section']/ul[@class='left']/li/a[contains(text(),'{$category}')]");
         $I->waitForText($link);
         $I->click($link, '#topnav_' . strtolower($category));
         $I->wait(1);


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [Y ] I've added comments to any new methods I've created or where else relevant.
- [? ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [? ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Fix for choke in CI Github actions and tests failing generally

<!-- List your changes as a dot point list. -->
## Removed array css assertion in call to Codeception WebDriver MouseOver

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: