### PR TITLE
fix: fixing ubuntu versions in docker

### DIFF
--- a/.build/environment/dev/configs/docker/Dockerfile.template
+++ b/.build/environment/dev/configs/docker/Dockerfile.template
@@ -1,5 +1,5 @@
 # ubuntu version limited for simple mysql5.7 packaging
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20220801
 
 # prevent install locking up o TZ or other user inputs
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.build/environment/prod/configs/docker/Dockerfile.template
+++ b/.build/environment/prod/configs/docker/Dockerfile.template
@@ -1,5 +1,5 @@
 # ubuntu version limited for simple mysql5.7 packaging
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20220801
 
 # prevent install locking up o TZ or other user inputs
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.build/environment/test/configs/docker/Dockerfile.template
+++ b/.build/environment/test/configs/docker/Dockerfile.template
@@ -1,5 +1,5 @@
 # ubuntu version limited for simple mysql5.7 packaging
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20220801
 
 # prevent install locking up o TZ or other user inputs
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [x] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [x] I've added comments to any new methods I've created or where else relevant.
- [x] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
Fixes the Ubuntu version used in Docker to an earlier version to ensure systemd is present as required by the version of PHP7.4 installed by the ondrej PPA

<!-- List your changes as a dot point list. -->
## Changelog
- Fix the Ubuntu version to Bionic 20220801 in the Docker templates

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information
This change causes the [PR](https://github.com/2pisoftware/cmfive-core/pull/167) of a similar fix to pass.

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: