### PR TITLE
Fix: Dev: PHP version hints for CI/CD into Composer

### DIFF
--- a/cmfive.php
+++ b/cmfive.php
@@ -342,7 +342,7 @@ function sketchComposerForCore($reference, $phpVersion)
     // 2nd cut default, to master vs deployed PHP version
     if (is_null($reference) || is_null($phpVersion)) {
             $reference = "master";
-            $phpVersion = isnull($phpVersion) ? (PHP_MAJOR_VERSION .".". PHP_MINOR_VERSION) : $phpVersion;
+            $phpVersion = is_null($phpVersion) ? (PHP_MAJOR_VERSION .".". PHP_MINOR_VERSION) : $phpVersion;
     }
 
     $composer_string = <<<COMPOSER


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (7.4 for current, 7.2 for legacy).
- [Y ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
PHP version hints for CI/CD into Composer

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: