### PR TITLE
Allow test nav helper to be re-entrant

### DIFF
--- a/test/Codeception/tests/boilerplate/acceptance/helpers/CmfiveSite.php
+++ b/test/Codeception/tests/boilerplate/acceptance/helpers/CmfiveSite.php
@@ -178,6 +178,12 @@ class CmfiveSite extends \Codeception\Module
             //$category, "section.top-bar-section ul.left"
             $I->waitForElement("//section[@class='top-bar-section']/ul[@class='left']/li/a[contains(text(),'{$category}')]", 2);
             $I->click("//section[@class='top-bar-section']/ul[@class='left']/li/a[contains(text(),'{$category}')]");
+            // New designs now emerging on whole module (not just specific actions)
+            // So we should check if first step navbar click flipped us into BootStrap:
+            if ($this->isUsingBootstrap5($I)) {
+                $I->clickCmfiveNavbar($I, $category, $link);
+                return;
+            }
             $I->moveMouseOver(['css' => '#topnav_' . strtolower($category)]);
             $I->waitForText($link);
             $I->click($link, '#topnav_' . strtolower($category));


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [Y ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [Y ] I've added comments to any new methods I've created or where else relevant.
- [n/a ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [n/a ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description
New designs now emerging on whole module at -->navigation level (not just specific actions)
So Codeception test must check if first step navbar click flipped over into BootStrap tpl before trying drop menu click-actions
            

<!-- List your changes as a dot point list. -->
## Changelog
Update Codeception nav-bar helper
