### PR TITLE
Remove healthcheck on test container (.cmfive-installed)

### DIFF
--- a/.codepipeline/test_agent/Dockerfile
+++ b/.codepipeline/test_agent/Dockerfile
@@ -63,8 +63,7 @@ RUN chmod -R 777 start.sh
 
 # Healthcheck to ensure nginx is running and cmfive is installed
 HEALTHCHECK --interval=10s --timeout=10s --start-period=5s --retries=15 \
-  CMD curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -q -E "^[1-3][0-9]{2}$" && \
-      test -f ~/.cmfive-installed
+  CMD curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -q -E "^[1-3][0-9]{2}$"
 
 RUN cd /etc/nginx && \
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout nginx.key -out nginx.crt -subj "/C=AU/ST=NSW/L=Bega/O=2pi/CN=localhost"


### PR DESCRIPTION
<!-- Have you made sure the following is correct? -->
## Checklist
- [ ] I'm using the correct PHP Version (8.1 for current, 7.4 for legacy).
- [ ] I've added comments to any new methods I've created or where else relevant.
- [ ] I've replaced magic method usage on DbService classes with the getInstance() static method.
- [ ] I've written any documentation for new features or where else relevant in the docs [repo](https://github.com/2pisoftware/cmfive-docs).

<!-- Add a short description. -->
## Description

<!-- List your changes as a dot point list. -->
## Changelog

<!-- Add any important refs or issues numbers. -->
refs:
issues:

<!-- Add any other information that might be relevant. -->
## Other Information

<!-- Link to the docs pull request if documentation changes have been made. -->
Docs pull request: