### PR TITLE
fix: Enable master builds for docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - develop
+      - master
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
When pushing to master it will release a :latest cmfive image