### PR TITLE
fix: Add rule for latest tag

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,6 +39,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
           labels: |
             org.opencontainers.image.title=Cmfive
             org.opencontainers.image.description=Cmfive in a docker image


### PR DESCRIPTION
Related to #146 which enabled master builds but didnt tag as :latest.