### PR TITLE
fix: Core branch name

### DIFF
--- a/.codepipeline/docker/setup.sh
+++ b/.codepipeline/docker/setup.sh
@@ -74,7 +74,7 @@ fi
 
 # System dir and composer packages must exist
 if [ ! -f "/var/www/html/system/web.php" ] || [ ! -f "/var/www/html/composer.json" ] || [ -n "$CMFIVE_CORE_BRANCH" ]; then
-    CMFIVE_CORE_BRANCH=${CMFIVE_CORE_BRANCH:-master} # Default to master if not set
+    CMFIVE_CORE_BRANCH=${CMFIVE_CORE_BRANCH:-main} # Default to main if not set
     rm -rf /var/www/html/system # Remove system dir to ensure correct core is installed
     echo "➕  Installing core from branch [ $CMFIVE_CORE_BRANCH ]"
     php cmfive.php install core $CMFIVE_CORE_BRANCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --no-cache add \
     git
 
 # Clone github.com/2pisoftware/cmfive-core
-ARG CORE_BRANCH=master
+ARG CORE_BRANCH=main
 RUN git clone --depth 1 https://github.com/2pisoftware/cmfive-core.git -b $CORE_BRANCH
 
 # Compile the theme

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The following options can be used with the Docker image. You may choose to use f
 
 The following build args can be used to customise the Docker image if you are building a custom one:
 
-- **CORE_BRANCH:** The branch of the cmfive-core repository to bake in at build-time. Defaults to `master`.
+- **CORE_BRANCH:** The branch of the cmfive-core repository to bake in at build-time. Defaults to `main`.
 - **PHP_VERSION:** The version of PHP to use. See alpine linux packages for available versions. Defaults to the version in the Dockerfile (eg 81).
 
 #### Volumes

--- a/cmfive.php
+++ b/cmfive.php
@@ -44,7 +44,7 @@ To add options:
 
 $menuMaker = [
     [
-        'option' => "Install core libraries", 'message' => "Installing core libraries", 'function' => "installCoreLibraries", 'param' => "master"
+        'option' => "Install core libraries", 'message' => "Installing core libraries", 'function' => "installCoreLibraries", 'param' => "main"
     ],
     [
         'option' => "Install database migrations", 'message' => "Installing migrations", 'function' => "installMigrations", 'param' => null
@@ -61,7 +61,7 @@ $cmdMaker = [
     'install' => [
         [
             'request' => "core", 'message' => "Installing core libraries", 'function' => "cmdinstallCoreLibraries", 'args' => true,
-            'hint' => "cmfive-core reference (default is 'master')", "default" => ['branch' => "master"]
+            'hint' => "cmfive-core reference (default is 'main')", "default" => ['branch' => "main"]
         ],
         [
             'request' => "migration", 'message' => "Installing migrations", 'function' => "installMigrations", 'args' => false
@@ -270,7 +270,7 @@ function installCoreLibraries($branch = null, $phpVersion = null)
     // name     : 2pisoftware/cmfive-core
     // descrip. :
     // keywords :
-    // versions : * master
+    // versions : * main
     // type     : library
     // source   : [git] https://github.com/2pisoftware/cmfive-core develop
     // dist     : []
@@ -321,7 +321,7 @@ function sketchComposerForCore($reference, $phpVersion)
     // name     : 2pisoftware/cmfive-core
     // descrip. :
     // keywords :
-    // versions : * master
+    // versions : * main
     // type     : library
     // source   : [git] https://github.com/2pisoftware/cmfive-core develop
     // dist     : []
@@ -337,7 +337,7 @@ function sketchComposerForCore($reference, $phpVersion)
             $phpVersion = "7.4";
         }
         if (is_null($reference) || is_null($phpVersion)) {
-            $reference = is_null($reference) ? "master" : $reference;
+            $reference = is_null($reference) ? "main" : $reference;
             $phpVersion = is_null($phpVersion) ? (PHP_MAJOR_VERSION .".". PHP_MINOR_VERSION) : $phpVersion;
         }
     }

--- a/test/Setup.txt
+++ b/test/Setup.txt
@@ -1,7 +1,7 @@
 
 1) Clone/pull/download: https://github.com/2pisoftware/cmfive-boilerplate
  - Position it nicely for WebServer to find
- - Match it to a CORE install (cmfive.php step[1] will clone MASTER from scratch)
+ - Match it to a CORE install (cmfive.php step[1] will clone main from scratch)
  - Make symlinks etc as required
  - Apply any other usual cmfive setup steps!
  - Enable TestRunner in cmfive-boilerplate\config.php:


### PR DESCRIPTION
Closes #161.

This fix targets cmfive-boilerplate develop as cmfive-boilerplate master branch works, it just uses an older core.