### PR TITLE
Feature: db strategy on docker tests

### DIFF
--- a/.codepipeline/docker/config.default.php
+++ b/.codepipeline/docker/config.default.php
@@ -13,7 +13,7 @@ Config::set("system.timezone", "Australia/Sydney");
 //========== Database Configuration ==========================
 Config::set("database", [
     "hostname"  => getenv('DB_HOST') ?: "mysqldb",
-    "port"  => getenv('DB_PORT') ?: "",
+    "port"      => getenv('DB_PORT') ?: "3306",
     "username"  => getenv('DB_USERNAME') ?: "cmfive",
     "password"  => getenv('DB_PASSWORD') ?: "cmfive",
     "database"  => getenv('DB_DATABASE') ?: "cmfive",

--- a/.codepipeline/docker/setup.sh
+++ b/.codepipeline/docker/setup.sh
@@ -27,6 +27,15 @@ if [ ! -f config.php ]; then
     cp /bootstrap/config.default.php config.php
 fi
 
+# Add custom config
+if [ -n "$CUSTOM_CONFIG" ]; then
+    echo "➕  Adding custom config"
+    # Remove existing custom config between markers
+    sed -i '/# BEGIN CUSTOM CONFIG/,/# END CUSTOM CONFIG/d' config.php
+    # Add new custom config
+    echo -e "\n# BEGIN CUSTOM CONFIG\n${CUSTOM_CONFIG}\n# END CUSTOM CONFIG" >> config.php
+fi
+
 #Ensure necessary directories have the correct permissions
 echo "Setting permissions"
 chmod ugo=rwX -R cache/ storage/ uploads/

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The following options can be used with the Docker image. You may choose to use f
 - **DB_DATABASE:** The name of the database
 - **DB_USERNAME:** The username to connect to the database
 - **DB_PASSWORD:** The password to connect to the database
+- **CUSTOM_COFIG:** (optional) Custom configuration to add to the config.php file.
 - **ENVIRONMENT:** (optional) The environment to run in (development, production). Defaults to production.
 - **INSTALL_CORE_BRANCH:** (optional) The branch of the cmfive-core repository to switch to while the container is starting. If not specified it will use the built-in core. Note: If this method is used, the theme will not be compiled automatically for the specified branch.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
     container_name: mysql-8
     hostname: mysql-8
     environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=cmfive
-      - MYSQL_PASSWORD=cmfive
-      - MYSQL_DATABASE=cmfive
-      - TZ=Australia/Sydney
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: cmfive
+      MYSQL_PASSWORD: cmfive
+      MYSQL_DATABASE: cmfive
+      TZ: Australia/Sydney
     volumes:
       - dbdata:/var/lib/mysql:delegated
     networks:
@@ -28,12 +28,14 @@ services:
     container_name: cmfive
     hostname: nginx-php8.1
     environment:
-      - TZ=Australia/Sydney
-      - DB_HOST=mysqldb
-      - DB_DATABASE=cmfive
-      - DB_USERNAME=cmfive
-      - DB_PASSWORD=cmfive
-      - ENVIRONMENT=development
+      TZ: Australia/Sydney
+      DB_HOST: mysqldb
+      DB_DATABASE: cmfive
+      DB_USERNAME: cmfive
+      DB_PASSWORD: cmfive
+      ENVIRONMENT: development
+      CUSTOM_CONFIG: |
+        Config::set('tests', ['testrunner' => 'ENABLED']);
     volumes:
       - ./:/var/www/html:rw
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       DB_DATABASE: cmfive
       DB_USERNAME: cmfive
       DB_PASSWORD: cmfive
+      DB_PORT: 3306
       ENVIRONMENT: development
       CUSTOM_CONFIG: |
         Config::set('tests', ['testrunner' => 'ENABLED']);

--- a/test/playwright/docker_run.sh
+++ b/test/playwright/docker_run.sh
@@ -40,6 +40,8 @@ if [ -z "$IS_PLAYWRIGHT_CONTAINER" ]; then
 
     docker run -it --rm \
         -e IS_PLAYWRIGHT_CONTAINER=1 \
+        -e LANG=en_AU.UTF-8 \
+        -e LC_ALL=en_AU.UTF-8 \
         -v ms-playwright-data-cmfive:/ms-playwright \
         -v $PROJECTDIR:/cmfive-boilerplate \
         --ipc=host \
@@ -99,6 +101,9 @@ wait_for_response() {
 }
 
 wait_for_response "http://localhost:3000" 60
+
+locale
+date
 
 cd /cmfive-boilerplate/test/playwright
 npm i

--- a/test/playwright/docker_run.sh
+++ b/test/playwright/docker_run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Exit on error
+set -e
+
 # This script is used to run the Playwright tests in a container
 # usage: ./docker_run.sh
 # Or to refresh the Cmfive Docker containers before running the tests
@@ -9,7 +12,11 @@
 if [ -z "$IS_PLAYWRIGHT_CONTAINER" ]; then
     # Explicitly prep DB for testing:
     echo "Backup and snaphsot DB with migrations"
-    docker exec -t cmfive bash -c "php cmfive.php testDB setup"
+    if docker exec -t cmfive bash -c "php cmfive.php testDB setup"; then
+        echo "Success: Setup test DB"
+    else
+        echo "Warning: Failed to setup test DB"
+    fi
 
     # Get the directory of the script
     TESTDIR=$(dirname -- "$( readlink -f -- "$0"; )";)
@@ -27,15 +34,23 @@ if [ -z "$IS_PLAYWRIGHT_CONTAINER" ]; then
         docker compose up -d --wait
     fi
 
+    docker build -t playwright-cosine -f $TESTDIR/playwright.Dockerfile $PROJECTDIR
+
+    set +e
+
     docker run -it --rm \
-         -e IS_PLAYWRIGHT_CONTAINER=1 \
-         -v $PROJECTDIR:/cmfive-boilerplate \
-         -v ms-playwright-data-cmfive:/ms-playwright \
-         --ipc=host \
-         --network=host \
-         --cap-add=SYS_ADMIN \
-         mcr.microsoft.com/playwright:v1.45.1-jammy \
-         "/cmfive-boilerplate/test/playwright/docker_run.sh"
+        -e IS_PLAYWRIGHT_CONTAINER=1 \
+        -v ms-playwright-data-cmfive:/ms-playwright \
+        -v $PROJECTDIR:/cmfive-boilerplate \
+        --ipc=host \
+        --network=host \
+        --cap-add=SYS_ADMIN \
+        playwright-cosine \
+        "/cmfive-boilerplate/test/playwright/docker_run.sh"
+        
+    DOCKER_EXIT_CODE=$?
+
+    set -e
 
     # OK, now we are done with the Playwright container
     # Consider cleanup:
@@ -52,7 +67,13 @@ if [ -z "$IS_PLAYWRIGHT_CONTAINER" ]; then
             open $TESTDIR/test-results
         fi
     fi
-    
+
+    if [ $DOCKER_EXIT_CODE -ne 0 ]; then
+        echo "Playwright container exited with code $DOCKER_EXIT_CODE"
+        exit $DOCKER_EXIT_CODE
+    fi
+
+    echo "Success: Playwright tests completed"
     exit
 fi
 
@@ -75,39 +96,18 @@ wait_for_response() {
     fi
     echo ""
     echo "$url responded"
-}   
+}
 
+wait_for_response "http://localhost:3000" 60
 
-# Australianise things:
-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
-locale-gen en_AU.UTF-8
-update-locale en_AU.UTF-8
-LANG=en_AU.UTF-8
-LC_ALL=en_AU.UTF-8
-locale
-
-apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq tzdata && \
-    ln -fs /usr/share/zoneinfo/Australia/Sydney /etc/localtime && \
-    dpkg-reconfigure -f noninteractive tzdata
-date
-
-# Shift into test environment
 cd /cmfive-boilerplate/test/playwright
-
 npm i
-npx playwright install
 npm run build
-# we don't need setup, as we intitiated it already from host CLI scope, before test container re-entry.
-# so, no: npm run setup
 
-wait_for_response "http://localhost:3000" 30
-
+# Run the tests, recommended 1 worker for Playwright for memory usage
 export WORKERS=1
 
-# unless we restore our 'empty' target DB, we cannot achieve useful retries!
-# this is the purpose of "npm_config_clean=true"
-# but node (from in here) will make a mess of the Playwright package.json Docker assumptions.
+# Retry failed tests, recommended 0 retries because of data consistency
 export RETRIES=0
 
 npm run test

--- a/test/playwright/playwright.Dockerfile
+++ b/test/playwright/playwright.Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/playwright:v1.45.1-jammy
+# Australianise things:
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
+    locale-gen en_AU.UTF-8 && \
+    update-locale en_AU.UTF-8 && \
+    LANG=en_AU.UTF-8 && \
+    LC_ALL=en_AU.UTF-8 && \
+    locale
+    
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -yq tzdata && \
+    ln -fs /usr/share/zoneinfo/Australia/Sydney /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    date
+
+# Shift into test environment
+WORKDIR /cmfive-boilerplate/test/playwright


### PR DESCRIPTION
## Description
Container strategy for node/ts Playwright test runner is challenged by access to also-containerised PHP DB helpers

## Changelog
Deprecate Container test runner affordance of 'npm/npx' DB helpers
Correctly scope DB helper tool calls vs local/container-re-entrant steps of test shell script
Add locale&TZ support to container setup